### PR TITLE
Install https-loader in 'getting started' notebook

### DIFF
--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -25,7 +25,7 @@
    },
    "cell_type": "code",
    "source": [
-    "! pip install delb\n",
+    "! pip install delb[https-loader]\n",
     "\n",
     "from delb import Document"
    ],


### PR DESCRIPTION
Because the `https_loader` is not part of the core loaders, the second cell in the 'Getting started' notebook fails when attempting to instantiate a `Document` from an `https://` source. Hence, delb should be installed with it's extra `https-loader` in the notebook's first cell.