### PR TITLE
WIP: Fixes parsing of attribute test predicate conjunctions in xpath queries

### DIFF
--- a/_delb/xpath.py
+++ b/_delb/xpath.py
@@ -86,6 +86,29 @@ class XPathExpression(UserString):
         return " | ".join(str(x) for x in self.location_paths)
 
     def is_unambiguously_locatable(self) -> bool:
+        """ determine whether an xpath expression addresses exactly one possible node.
+
+        can't have multiple paths:
+
+        >>> XPathExpression('./path1|./path2').is_unambiguously_locatable()
+        False
+
+        can't have path not starting at root:
+
+        >>> XPathExpression('/path').is_unambiguously_locatable()
+        False
+
+        can't have path that is not strictly hierarchical:
+
+        >>> XPathExpression('./root/node/descendant::foo').is_unambiguously_locatable()
+        False
+
+        can't have predicates with OR operator:
+
+        >>> XPathExpression('./node[@a="1" or @b="2"]').is_unambiguously_locatable()
+        False
+
+        """
         if len(self.location_paths) != 1:
             return False
 
@@ -101,8 +124,6 @@ class XPathExpression(UserString):
             predicates = step.predicates
             if not predicates:
                 continue
-            if len(predicates) > 1:
-                return False
 
             predicate = predicates[0]
             if predicate.type != "attribute_test":

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -91,6 +91,16 @@ def test_fetch_or_create_by_xpath_with_attributes():
     )
 
 
+def test_fetch_or_create_by_xpath_with_multiple_attributes():
+    root = Document('<root xmlns:foo="bar"/>').root
+
+    assert str(
+        root.fetch_or_create_by_xpath(
+            './entry/sense/cit[@type="translation" and @lang="en"]'
+        )
+    ) == '<cit type="translation" lang="en"/>'
+
+
 def test_fetch_or_create_by_xpath_with_prefixes_attributes():
     root = Document('<root xmlns:foo="bar"/>').root
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -100,6 +100,12 @@ def test_fetch_or_create_by_xpath_with_multiple_attributes():
         )
     ) == '<cit type="translation" lang="en"/>'
 
+    assert str(
+        root.fetch_or_create_by_xpath(
+            './entry/sense/cit[@type="translation"][@lang="en"]'
+        )
+    ) == '<cit type="translation" lang="en"/>'
+
 
 def test_fetch_or_create_by_xpath_with_prefixes_attributes():
     root = Document('<root xmlns:foo="bar"/>').root


### PR DESCRIPTION
Splitting an expression at the delimiter `" and "` would be handled incorrectly, resulting in segments starting with whitespace, which would cause determination of query ambiguity always fail.

Conjunction of attribute tests in seperate square brackets wasn't permitted, even though it could be.