### PR TITLE
The better solution for nodes' identity consistency

### DIFF
--- a/_delb/plugins/__init__.py
+++ b/_delb/plugins/__init__.py
@@ -15,12 +15,12 @@
 
 from inspect import isclass
 from types import SimpleNamespace
-from typing import Any, Callable, Dict, Iterable, Type, Union
+from typing import Any, Callable, Dict, Iterable, Type
 from warnings import warn
 
 import pkg_resources
 
-from _delb.typing import Loader
+from _delb.typing import Loader, LoaderConstraint
 
 
 class DocumentMixinHooks:
@@ -58,9 +58,6 @@ class DocumentExtensionHooks(DocumentMixinHooks):
             stacklevel=2,
         )
         super().__init__(*args, **kwargs)
-
-
-LoaderConstraint = Union[Loader, Iterable[Loader], None]
 
 
 class PluginManager:

--- a/_delb/plugins/core_loaders.py
+++ b/_delb/plugins/core_loaders.py
@@ -45,7 +45,7 @@ def tag_node_loader(data: Any, config: SimpleNamespace) -> LoaderResult:
         root = data.clone(deep=True)
         tree._setroot(root._etree_obj)
         utils._copy_root_siblings(data._etree_obj, root._etree_obj)
-        return tree, root._wrapper_cache
+        return tree
     return "The input value is not a TagNode instance."
 
 
@@ -56,9 +56,9 @@ def etree_loader(data: Any, config: SimpleNamespace) -> LoaderResult:
     :class:`lxml.etree._ElementTree` instances.
     """
     if isinstance(data, etree._ElementTree):
-        return deepcopy(data), {}
+        return deepcopy(data)
     if isinstance(data, etree._Element):
-        return etree.ElementTree(element=deepcopy(data), parser=config.parser), {}
+        return etree.ElementTree(element=deepcopy(data), parser=config.parser)
     return "The input value is neither an etree.Element or …Tree instance."
 
 
@@ -86,7 +86,7 @@ def buffer_loader(data: Any, config: SimpleNamespace) -> LoaderResult:
             data.seek(0)
         except UnsupportedOperation:
             pass
-        return etree.parse(cast(IO, data), parser=config.parser), {}
+        return etree.parse(cast(IO, data), parser=config.parser)
     return "The input value is no buffer object."
 
 
@@ -98,7 +98,7 @@ def ftp_http_loader(data: Any, config: SimpleNamespace) -> LoaderResult:
     """
     if isinstance(data, str) and data.lower().startswith(("http://", "ftp://")):
         config.source_url = data
-        return etree.parse(data, parser=config.parser), {}
+        return etree.parse(data, parser=config.parser)
     return "The input value is not an URL with the ftp or http scheme."
 
 
@@ -111,7 +111,7 @@ def text_loader(data: Any, config: SimpleNamespace) -> LoaderResult:
         data = data.encode()
     if isinstance(data, bytes):
         root = etree.fromstring(data, config.parser)
-        return etree.ElementTree(element=root), {}
+        return etree.ElementTree(element=root)
     return "The input value is not a byte sequence."
 
 

--- a/_delb/typing.py
+++ b/_delb/typing.py
@@ -15,20 +15,20 @@
 
 
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, Union
 
 from lxml import etree
 
 if TYPE_CHECKING:
-    from _delb.nodes import _ElementWrappingNode, NodeBase, _TagDefinition
+    from _delb.nodes import NodeBase, _TagDefinition
 
 
 Filter = Callable[["NodeBase"], bool]
 NodeSource = Union[str, "NodeBase", "_TagDefinition"]
-_WrapperCache = Dict[int, "_ElementWrappingNode"]
 
-LoaderResult = Union[Tuple[Optional[etree._ElementTree], _WrapperCache], str]
+LoaderResult = Union[Optional[etree._ElementTree], str]
 Loader = Callable[[Any, SimpleNamespace], LoaderResult]
+LoaderConstraint = Union[Loader, Iterable[Loader], None]
 
 
 __all__ = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,14 +11,36 @@ FILES_PATH = Path(__file__).parent / "files"
 RESULTS_FILE = FILES_PATH / ".result.xml"
 
 
+_referenced_objects_for_wrapper_cache_tests = {}
+
+
 @fixture()
 def files_path():
     yield FILES_PATH
 
 
 @fixture()
+def long_term_references():
+    yield _referenced_objects_for_wrapper_cache_tests
+
+
+@fixture()
 def result_file():
     yield RESULTS_FILE
+
+
+@fixture()
+def queries_sample():
+    yield Document(
+        """\
+            <root>
+                <node n="1"/>
+                <node n="2"/>
+                <node/>
+                <node n="3"/>
+            </root>
+        """
+    )
 
 
 @fixture()
@@ -34,4 +56,29 @@ def sample_document():
         "</p>"
         "</text>"
         "</doc>"
+    )
+
+
+@fixture()
+def traverser_sample():
+    yield Document(
+        """\
+            <root>
+                <a>
+                    <aa/>
+                    <ab>
+                        <aba/>
+                    </ab>
+                    <ac/>
+                </a>
+                <b/>
+                <c>
+                    <ca>
+                        <caa/>
+                        <cab/>
+                    </ca>
+                    <cb/>
+                </c>
+            </root>
+        """
     )

--- a/tests/test_aaa_setup_wrapper_cache.py
+++ b/tests/test_aaa_setup_wrapper_cache.py
@@ -1,0 +1,15 @@
+from delb import Document
+
+
+# these objects will be used in test_zzz_wrapper_cache
+def test_setup_long_term_references(long_term_references):
+    long_term_references["a_document"] = Document("<document/>")
+
+    root = Document("<root>a</root>").root
+    root.append_child("b")
+    long_term_references["appended_b"] = root.last_child
+
+    root = Document("<root>a</root>").root
+    root.append_child("b")
+    root.append_child("c")
+    long_term_references["appended_b_with_c"] = root.last_child

--- a/tests/test_comment_and_pi_nodes.py
+++ b/tests/test_comment_and_pi_nodes.py
@@ -8,6 +8,12 @@ from delb import (
 )
 
 
+def test_appended_text_node():
+    document = Document("<root><!-- c -->tail</root>")
+    document.root.last_child.add_next("|appended")
+    assert str(document) == "<root><!-- c -->tail|appended</root>"
+
+
 def test_comment_node():
     document = Document("<root><tag/><!-- comment -->text</root>")
     root = document.root

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -82,8 +82,11 @@ def test_contains():
     document_a = Document("<root><a/></root>")
     document_b = Document("<root><a/></root>")
 
-    assert document_a.root[0] in document_a
-    assert document_a.root[0] not in document_b
+    a = document_a.root[0]
+    gc.collect()
+
+    assert a in document_a
+    assert a not in document_b
 
 
 def test_css_select():
@@ -120,27 +123,6 @@ def test_mro():
         DocumentMixinHooks,
         object,
     )
-
-
-def test_object_persistance():
-    document = Document(
-        "<eegohchivahgahsheiyeelooreepiaphahvaikohdaecobeavepaeyoicuevasan/>"
-    )
-    document_id = id(document)
-    root = document.root
-
-    del document
-    gc.collect()
-    assert root.document is not None
-
-    del root
-    gc.collect()
-    for obj in gc.get_objects():
-        if id(obj) == document_id and isinstance(obj, Document):
-            assert (
-                obj.root.local_name
-                != "eegohchivahgahsheiyeelooreepiaphahvaikohdaecobeavepaeyoicuevasan"
-            )
 
 
 def test_set_root():

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -8,18 +8,6 @@ from delb import Document, InvalidOperation, is_tag_node, tag
 DELB_VERSION = pkg_resources.get_distribution("delb").parsed_version.release
 
 
-sample_document = Document(
-    """\
-<root>
-    <node n="1"/>
-    <node n="2"/>
-    <node/>
-    <node n="3"/>
-</root>
-"""
-)
-
-
 def test_css_considers_xml_namespace(files_path):
     document = Document("<root><xml:node/><node/></root>")
     assert document.css_select("xml|node").size == 1
@@ -178,8 +166,8 @@ def test_quotes_in_css_selector():
         assert document.css_select('a[href$="123"]').size == 1
 
 
-def test_results_as_other_type():
-    results = sample_document.css_select("node")
+def test_results_as_other_type(queries_sample):
+    results = queries_sample.css_select("node")
 
     as_list = results.as_list()
     assert isinstance(as_list, list)
@@ -190,17 +178,17 @@ def test_results_as_other_type():
     assert len(as_tuple) == 4
 
 
-def test_results_filtered_by():
+def test_results_filtered_by(queries_sample):
     def has_n_attribute(node):
         return node.attributes.get("n") is not None
 
-    assert sample_document.css_select("node").filtered_by(has_n_attribute).size == 3
+    assert queries_sample.css_select("node").filtered_by(has_n_attribute).size == 3
 
 
-def test_results_first_and_last():
-    assert sample_document.css_select("node").first.attributes["n"] == "1"
-    assert sample_document.css_select("node").last.attributes["n"] == "3"
+def test_results_first_and_last(queries_sample):
+    assert queries_sample.css_select("node").first.attributes["n"] == "1"
+    assert queries_sample.css_select("node").last.attributes["n"] == "3"
 
 
-def test_results_size():
-    assert sample_document.css_select("node").size == 4
+def test_results_size(queries_sample):
+    assert queries_sample.css_select("node").size == 4

--- a/tests/test_traversers.py
+++ b/tests/test_traversers.py
@@ -1,28 +1,6 @@
 from pytest import mark
 
-from delb import Document, get_traverser, is_tag_node
-
-document = Document(
-    """\
-<root>
-    <a>
-        <aa/>
-        <ab>
-            <aba/>
-        </ab>
-        <ac/>
-    </a>
-    <b/>
-    <c>
-        <ca>
-            <caa/>
-            <cab/>
-        </ca>
-        <cb/>
-    </c>
-</root>
-"""
-)
+from delb import get_traverser, is_tag_node
 
 
 @mark.parametrize(
@@ -42,10 +20,10 @@ document = Document(
         ),
     ),
 )
-def test_traverser(from_left, depth_first, from_top, result):
+def test_traverser(traverser_sample, from_left, depth_first, from_top, result):
     assert [
         x.local_name
         for x in get_traverser(
             from_left=from_left, depth_first=depth_first, from_top=from_top
-        )(document.root, is_tag_node)
+        )(traverser_sample.root, is_tag_node)
     ] == result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,16 +21,11 @@ def test_first():
         first({})
 
 
-@pytest.mark.parametrize(
-    "obj",
-    (
-        Document("<pb n='[III]'/>").root["n"],
-        Document("<root>[III]</root>").root.first_child,
-    ),
-)
-def test_value_strip(obj):
-    assert obj == "[III]"
-    assert obj.startswith("[")
-    assert "III" in obj
-    assert obj.strip("[]") == "III"
-    assert obj[1:-1] == "III"
+def test_value_strip():
+    root = Document("<root n='[III]'>[III]</root>").root
+    for obj in (root["n"], root.first_child):
+        assert obj == "[III]"
+        assert obj.startswith("[")
+        assert "III" in obj
+        assert obj.strip("[]") == "III"
+        assert obj[1:-1] == "III"

--- a/tests/test_zzz_wrapper_cache.py
+++ b/tests/test_zzz_wrapper_cache.py
@@ -1,0 +1,70 @@
+import gc
+
+from delb import is_tag_node, is_text_node, tag, Document
+from _delb.nodes import NodeBase, TagNode, _wrapper_cache
+
+
+# the test order in this module matters!
+# the thirst three tests ensure that the garbage collection doesn't act when not
+# supposed to.
+# also see test_aaa_setup_wrapper_cache.py
+# the fourth one verifies that the garbage collection actually has cleaned everything
+# when no delb objects were used by an application (test suite in this case)
+# finally, the last test tests the gc in a nutshell
+
+
+def test_document_root_sustains(long_term_references):
+    gc.collect()
+    document = long_term_references.pop("a_document")
+    assert isinstance(document.root, TagNode)
+
+
+def test_referenced_appendees_sustain(long_term_references):
+    for name in ("appended_b", "appended_b_with_c"):
+        gc.collect()
+        b = long_term_references.pop(name)
+        assert b in b.parent
+        assert b.parent.first_child == "a"
+
+
+def test_appended_text_contents_arent_lost():
+    root = Document("<root><a><b><c><d/></c></b></a></root>").root
+
+    for node in tuple(root.child_nodes(is_tag_node, recurse=True)):
+        node.prepend_child("D")
+        node.add_next("T")
+    for node in tuple(root.child_nodes(is_text_node, recurse=True)):
+        node.add_next("Z")
+
+    gc.collect()
+    assert str(root) == "<root><a>DZ<b>DZ<c>DZ<d>DZ</d>TZ</c>TZ</b>TZ</a>TZ</root>"
+
+
+def test_no_dangling_objects(long_term_references):
+    assert not long_term_references
+
+    gc.collect()
+    gc.collect()
+
+    assert not _wrapper_cache.wrappers
+
+    unexpected = []
+    for obj in gc.get_objects():
+        if isinstance(obj, (Document, NodeBase)):
+            unexpected.append(obj)
+    assert len(unexpected) == 0
+
+
+def test_wrapper_cache():
+    gc.collect()
+    assert len(_wrapper_cache.wrappers) == 0
+
+    root = Document("<root/>").root
+    assert len(_wrapper_cache.wrappers) == 1
+
+    root.append_child(tag("node"))
+    assert len(_wrapper_cache.wrappers) == 2
+
+    root.first_child.detach()
+    gc.collect()
+    assert len(_wrapper_cache.wrappers) == 1


### PR DESCRIPTION
i looked into incorrectly behaving user code due to multiple wrapper instances for one node and quickly nailed down a problem that could be detected in [`_get_or_create_element_wrapper`](https://github.com/funkyfuture/delb/blob/cb47be39fc76e9b22087f7ed5816e02489691b5f/_delb/nodes.py#L83-L96): a wrapper that was retrieved from a cache didn't always own that same cache, which would have been expected given the overall idea how wrappers shall be preserved for a meaningful lifetime. so i created some meaningful lifetime for myself, emotionally comparable to the story they tell about the Lebowski, and i don't remember how that story ends, but i'm erquickt with this one. this state was also tested within a web application

it is surely not easy to review, and to make things more challenging, i included minor unrelated changes, sorry. it's likely best to start studying the new test module and with `_delb.nodes._WrapperCache`. playing around with it and the changes should explain ~~all~~, well, most other changes. of course i can give hints on mysteries that appear.

as this pr sits on top of #31, that one should be merged first and then i rebase here. the essential commit here deserves its own focus.