### PR TITLE
Adds workaround for issue with mybinder.org notebook

### DIFF
--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -28,6 +28,8 @@
    "source": [
     "! pip install delb[https-loader]\n",
     "\n",
+    "# workaround for issue with entrypoint registration on mybinder.org\n",
+    "from _delb.plugins import https_loader # not necessary in local environments\n",
     "from delb import Document"
    ],
    "execution_count": null,


### PR DESCRIPTION
The *Getting Started* notebook, when running on mybinder.org, seems to fail to load/register the `https-loader` plugin entrypoint, which leads to the `https_loader` document loader not being available during execution of the first code example. Explicitly importing the `https_loaders` module should register the loader and thereby provide a workaround for this problem for now.